### PR TITLE
Use `kairosdb.reporter.ttl` for ThreadReporter TTLs

### DIFF
--- a/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
+++ b/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
@@ -40,6 +40,8 @@ public class MetricReportingModule extends ServletModule
 		KairosMetricReporterListProvider reporterProvider = new KairosMetricReporterListProvider();
 		bind(KairosMetricReporterListProvider.class).toInstance(reporterProvider);
 
+		requestStaticInjection(ThreadReporter.class);
+
 		bindListener(Matchers.any(), reporterProvider);
 	}
 }

--- a/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
+++ b/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
@@ -17,6 +17,8 @@
 package org.kairosdb.core.reporting;
 
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import org.kairosdb.core.datapoints.LongDataPointFactory;
 import org.kairosdb.core.datapoints.StringDataPointFactory;
 import org.kairosdb.core.exception.DatastoreException;
@@ -38,7 +40,11 @@ import java.util.TreeMap;
  */
 public class ThreadReporter
 {
-	private static class ReporterDataPoint
+	static final String REPORTER_TTL_KEY = "kairosdb.reporter.ttl";
+	@Named(REPORTER_TTL_KEY)
+	private static int DEFAULT_REPORTER_TTL = 0;
+
+	/* package */ static class ReporterDataPoint
 	{
 		private final String m_metricName;
 		private final long m_value;
@@ -159,7 +165,7 @@ public class ThreadReporter
 
 	public static ReporterDataPoint addDataPoint(String metric, long value)
 	{
-		return addDataPoint(metric, value, 0);
+		return addDataPoint(metric, value, DEFAULT_REPORTER_TTL);
 	}
 
 	public static ReporterDataPoint addDataPoint(String metric, long value, int ttl)
@@ -173,7 +179,7 @@ public class ThreadReporter
 
 	public static ReporterDataPoint addDataPoint(String metric, String value)
 	{
-		return addDataPoint(metric, value, 0);
+		return addDataPoint(metric, value, DEFAULT_REPORTER_TTL);
 	}
 
 	public static ReporterDataPoint addDataPoint(String metric, String value, int ttl)

--- a/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
+++ b/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
@@ -40,7 +40,9 @@ import java.util.TreeMap;
  */
 public class ThreadReporter
 {
-	static final String REPORTER_TTL_KEY = "kairosdb.reporter.ttl";
+	private static final String REPORTER_TTL_KEY = "kairosdb.reporter.ttl";
+
+	@Inject
 	@Named(REPORTER_TTL_KEY)
 	private static int DEFAULT_REPORTER_TTL = 0;
 

--- a/src/test/java/org/kairosdb/core/reporting/ThreadReporterTest.java
+++ b/src/test/java/org/kairosdb/core/reporting/ThreadReporterTest.java
@@ -1,0 +1,35 @@
+package org.kairosdb.core.reporting;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.google.inject.servlet.ServletModule;
+import org.junit.Test;
+import org.kairosdb.core.http.rest.ResourceBase;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+
+
+public class ThreadReporterTest extends ResourceBase {
+    @Test
+    public void testInjection() throws Exception
+    {
+        Injector injector = Guice.createInjector(new ServletModule() {
+            @Override
+            protected void configureServlets() {
+                bind(Integer.TYPE).annotatedWith(Names.named("kairosdb.reporter.ttl")).toInstance(12345);
+                requestStaticInjection(ThreadReporter.class);
+            }
+        });
+        injector.getAllBindings();
+        System.out.println(injector.getAllBindings().toString());
+
+        // when
+        final ThreadReporter.ReporterDataPoint dataPoint = ThreadReporter.addDataPoint("metric name", "value");
+
+        // then
+        assertThat(dataPoint.getTtl(), greaterThan(0));
+
+    }
+}

--- a/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
@@ -127,6 +127,8 @@ public class H2DatastoreTest extends DatastoreTestHelper
 	public void test_serviceKeyStore_singleService()
 			throws DatastoreException
 	{
+		// NOTE (wittekm, July 2020) - This test appears to be flaky; we should dependency-inject a Time Provider.
+		// I will do this ASAP in a separate diff
 		h2Datastore.setValue("Service", "ServiceKey", "key1", "value1");
 		h2Datastore.setValue("Service", "ServiceKey", "key2", "value2");
 		h2Datastore.setValue("Service", "ServiceKey", "foo", "value3");


### PR DESCRIPTION
Sadly, adding datapoints through ThreadReporter assumes ttl=0, which breaks align_ttl.

This makes it use the same reporter TTL as in MetricReporterService.

(compare with internal bug https://jira.corp.dropbox.com/browse/OBS-1449 )