### PR TITLE
Fix KairosDB rowKey and metricName caches

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -122,7 +122,7 @@ public class BatchHandler extends RetryCallable
 					tags);
 
 			//Write out the row key if it is not cached
-			DataPointsRowKey cachedKey = m_rowKeyCache.cacheItem(rowKey);
+			DataPointsRowKey cachedKey = m_rowKeyCache.get(rowKey);
 			if (cachedKey == null)
 			{
 				batch.addRowKey(metricName, rowKey, rowKeyTtl);
@@ -133,7 +133,7 @@ public class BatchHandler extends RetryCallable
 				rowKey = cachedKey;
 
 			//Write metric name if not in cache
-			String cachedName = m_metricNameCache.cacheItem(metricName);
+			String cachedName = m_metricNameCache.get(metricName);
 			if (cachedName == null)
 			{
 				if (metricName.length() == 0)

--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -123,7 +123,6 @@ public class BatchHandler extends RetryCallable
 
 			//Write out the row key if it is not cached
 			DataPointsRowKey cachedKey = m_rowKeyCache.get(rowKey);
-			m_rowKeyCache.put(rowKey);
 			if (cachedKey == null)
 			{
 				batch.addRowKey(metricName, rowKey, rowKeyTtl);
@@ -135,7 +134,6 @@ public class BatchHandler extends RetryCallable
 
 			//Write metric name if not in cache
 			String cachedName = m_metricNameCache.get(metricName);
-			m_metricNameCache.put(metricName);
 			if (cachedName == null)
 			{
 				if (metricName.length() == 0)
@@ -179,6 +177,9 @@ public class BatchHandler extends RetryCallable
 
 					batch.submitBatch();
 
+					// The writes went through, so populate the caches accordingly.
+					batch.getMetricNames().forEach(m_metricNameCache::put);
+					batch.getRowKeys().forEach(m_rowKeyCache::put);
 				}
 
 			}

--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -123,6 +123,7 @@ public class BatchHandler extends RetryCallable
 
 			//Write out the row key if it is not cached
 			DataPointsRowKey cachedKey = m_rowKeyCache.get(rowKey);
+			m_rowKeyCache.put(rowKey);
 			if (cachedKey == null)
 			{
 				batch.addRowKey(metricName, rowKey, rowKeyTtl);
@@ -134,6 +135,7 @@ public class BatchHandler extends RetryCallable
 
 			//Write metric name if not in cache
 			String cachedName = m_metricNameCache.get(metricName);
+			m_metricNameCache.put(metricName);
 			if (cachedName == null)
 			{
 				if (metricName.length() == 0)

--- a/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
@@ -15,9 +15,12 @@ import javax.inject.Named;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.kairosdb.datastore.cassandra.CassandraConfiguration.KEYSPACE_PROPERTY;
@@ -44,6 +47,9 @@ public class CQLBatch
 	private BatchStatement dataPointBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
 	private BatchStatement rowKeyBatch = new BatchStatement(BatchStatement.Type.UNLOGGED);
 
+	private final List<String> m_metricNames = new ArrayList<>();
+	private final List<DataPointsRowKey> m_rowKeys = new ArrayList<>();
+
 	@Inject
 	@Named(KEYSPACE_PROPERTY)
 	private String m_keyspace = "kairosdb";
@@ -64,6 +70,8 @@ public class CQLBatch
 
 	public void addRowKey(String metricName, DataPointsRowKey rowKey, int rowKeyTtl)
 	{
+		m_rowKeys.add(rowKey);
+
 		ByteBuffer bb = ByteBuffer.allocate(8);
 		bb.putLong(0, rowKey.getTimestamp());
 
@@ -94,6 +102,8 @@ public class CQLBatch
 
 	public void addMetricName(String metricName)
 	{
+		m_metricNames.add(metricName);
+
 		BoundStatement bs = new BoundStatement(m_schema.psStringIndexInsert);
 		bs.setBytesUnsafe(0, ByteBuffer.wrap(ROW_KEY_METRIC_NAMES.getBytes(UTF_8)));
 		bs.setString(1, metricName);
@@ -189,5 +199,13 @@ public class CQLBatch
 			m_session.execute(dataPointBatch);
 			m_batchStats.addDatapointsBatch(dataPointBatch.size());
 		}
+	}
+
+	public Collection<String> getMetricNames() {
+		return m_metricNames;
+	}
+
+	public Collection<DataPointsRowKey> getRowKeys() {
+		return m_rowKeys;
 	}
 }

--- a/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
@@ -17,6 +17,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -202,10 +203,10 @@ public class CQLBatch
 	}
 
 	public Collection<String> getMetricNames() {
-		return m_metricNames;
+		return Collections.unmodifiableCollection(m_metricNames);
 	}
 
 	public Collection<DataPointsRowKey> getRowKeys() {
-		return m_rowKeys;
+		return Collections.unmodifiableCollection(m_rowKeys);
 	}
 }

--- a/src/main/java/org/kairosdb/datastore/cassandra/DataCache.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/DataCache.java
@@ -74,14 +74,14 @@ public class DataCache<T>
 	 */
 	public synchronized T get(T cacheData)
 	{
-		final LinkItem<T> mappedItem = getMappedItem(cacheData);
+		final LinkItem<T> mappedItem = getMappedItemAndUpdateLRU(cacheData);
 
 		pruneCache();
 
 		return (mappedItem == null ? null : mappedItem.m_data);
 	}
 
-	private synchronized LinkItem<T> getMappedItem(T cacheData) {
+	private synchronized LinkItem<T> getMappedItemAndUpdateLRU(T cacheData) {
 		final LinkItem<T> mappedItem = m_hashMap.get(cacheData);
 
 		if (mappedItem != null)
@@ -96,7 +96,7 @@ public class DataCache<T>
 
 
 	public synchronized void put(final T cacheData) {
-		final LinkItem<T> existing = getMappedItem(cacheData);
+		final LinkItem<T> existing = m_hashMap.get(cacheData);
 		if (existing != null) {
 			return;
 		}

--- a/src/test/java/org/kairosdb/datastore/cassandra/DataCacheTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/DataCacheTest.java
@@ -57,16 +57,17 @@ public class DataCacheTest
 	{
 		DataCache<String> cache = new DataCache<String>(3);
 
-		assertNull(cache.cacheItem("one"));
-		assertNull(cache.cacheItem("two"));
-		assertNull(cache.cacheItem("three"));
+		cache.put("one");
+		cache.put("two");
+		cache.put("three");
 
-		assertNotNull(cache.cacheItem("one")); //This puts 'one' as the newest
-		assertNull(cache.cacheItem("four")); //This should boot out 'two'
-		assertNull(cache.cacheItem("two")); //Should have booted 'three'
-		assertNotNull(cache.cacheItem("one"));
-		assertNull(cache.cacheItem("three")); //Should have booted 'four'
-		assertNotNull(cache.cacheItem("one"));
+		cache.put("one");
+		assertNotNull(cache.get("one")); //This puts 'one' as the newest
+		cache.put("four"); //This should boot out 'two'
+		assertNull(cache.get("two")); //Should have booted 'three'
+		cache.put("one");
+		cache.put("three"); //Should have booted 'four'
+		assertNotNull(cache.get("one"));
 	}
 
 	@Test
@@ -78,17 +79,17 @@ public class DataCacheTest
 
 		DataCache<TestObject> cache = new DataCache<TestObject>(10);
 
-		cache.cacheItem(td1);
-		cache.cacheItem(td2);
-		cache.cacheItem(td3);
+		cache.put(td1);
+		cache.put(td2);
+		cache.put(td3);
 
-		TestObject ret = cache.cacheItem(new TestObject("td1"));
+		TestObject ret = cache.get(new TestObject("td1"));
 		assertTrue(td1 == ret);
 
-		ret = cache.cacheItem(new TestObject("td2"));
+		ret = cache.get(new TestObject("td2"));
 		assertTrue(td2 == ret);
 
-		ret = cache.cacheItem(new TestObject("td3"));
+		ret = cache.get(new TestObject("td3"));
 		assertTrue(td3 == ret);
 	}
 }


### PR DESCRIPTION
See https://github.com/InscopeMetrics/kairosdb/pull/3 for an explanation of the bug this fixes.

Unfortunately, this code is laden with factories, so I'm not sure how to unit test it without extensive refactoring. :crossed_fingers: 