### PR TITLE
Upgrade Jackson to 2.9.10 which is the current version used throughout ISM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
     <guava.version>19.0</guava.version>
     <guice.version>4.1.0</guice.version>
     <guava.retrying.version>2.0.0</guava.retrying.version>
-    <jackson.version>2.2.3</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
     <javax.inject.version>1</javax.inject.version>
     <javax.servlet.version>3.0.0.v201112011016</javax.servlet.version>
     <javax.validation.api.version>1.0.0.GA</javax.validation.api.version>
@@ -458,6 +458,7 @@
                   </bind>
                 </volumes>
                 <wait>
+                  <time>30000</time>
                   <http>
                     <url>http://${kairosdb.ip}:8080/api/v1/health/status</url>
                     <method>GET</method>

--- a/src/main/java/org/kairosdb/core/http/rest/json/DataPointDeserializer.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/DataPointDeserializer.java
@@ -38,11 +38,14 @@ public class DataPointDeserializer extends JsonDeserializer<List<DataPointReques
 	@Override
 	public List<DataPointRequest> deserialize(JsonParser parser, DeserializationContext deserializationContext) throws IOException
 {
-		List<DataPointRequest> datapoints = new ArrayList<DataPointRequest>();
+		List<DataPointRequest> datapoints = new ArrayList<>();
 
 		JsonToken token = parser.nextToken();
 		if (token != JsonToken.START_ARRAY )
-			throw deserializationContext.mappingException("Invalid data point syntax.");
+			deserializationContext.reportWrongTokenException(
+					DataPointRequest.class,
+					JsonToken.START_ARRAY,
+					"Invalid data point syntax.");
 
 	while(token != null && token != JsonToken.END_ARRAY)
 		{
@@ -59,7 +62,10 @@ public class DataPointDeserializer extends JsonDeserializer<List<DataPointReques
 
 			token = parser.nextToken();
 			if (token != JsonToken.END_ARRAY)
-				throw deserializationContext.mappingException("Invalid data point syntax.");
+				deserializationContext.reportWrongTokenException(
+						DataPointRequest.class,
+						JsonToken.END_ARRAY,
+						"Invalid data point syntax.");
 
 			token = parser.nextToken();
 		}


### PR DESCRIPTION
Aside from long-overdue hygiene, the Jackson upgrade will permit the use of `JavaPropsMapper` from Jackson for mapping Properties to objects.